### PR TITLE
add dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,3 +7,5 @@ license = "GPL-3.0"
 author = "phastboy"
 
 [dependencies]
+clap = { version = "4.5.24", features = ["derive"] }
+dialoguer = "0.11.0"


### PR DESCRIPTION
This pull request includes updates to the `Cargo.toml` file to add new dependencies.

Dependency additions:

* [`Cargo.toml`](diffhunk://#diff-2e9d962a08321605940b5a657135052fbcef87b5e360662bb527c96d9a615542R10-R11): Added `clap` version `4.5.24` with the `derive` feature.
* [`Cargo.toml`](diffhunk://#diff-2e9d962a08321605940b5a657135052fbcef87b5e360662bb527c96d9a615542R10-R11): Added `dialoguer` version `0.11.0`.