### PR TITLE
Prompt for commit type

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,12 @@ version = "0.0.0"
 edition = "2021"
 description = "A CLI tool that help you write conventional commit messages interactively."
 license = "GPL-3.0"
-author = "phastboy"
+authors = ["phastboy stationphast@gmail.com"]
+readme = "README.md"
+homepage = "https://github.com/phastboy/commando"
+repository = "https://github.com/phastboy/commando"
+keywords = ["cli", "search", "demo"]
+categories = ["command-line-utilities"]
 
 [dependencies]
 clap = { version = "4.5.24", features = ["derive"] }

--- a/src/interactive.rs
+++ b/src/interactive.rs
@@ -1,3 +1,16 @@
+use dialoguer::Select;
+
 pub fn run_interactive() {
-    println!("Interactive commit flow coming soon!");
+    // commit types
+    let commit_types = vec!["feat", "fix", "chore", "docs", "refactor", "test"];
+
+    // prompt for commit type
+    let commit_type = Select::new()
+        .with_prompt("Select the type of change")
+        .items(&commit_types)
+        .default(0)
+        .interact()
+        .expect("Failed to select commit type");
+
+    println!("Selected commit type: {}", commit_types[commit_type]);
 }

--- a/src/interactive.rs
+++ b/src/interactive.rs
@@ -1,0 +1,3 @@
+pub fn run_interactive() {
+    println!("Interactive commit flow coming soon!");
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,3 +1,6 @@
+mod interactive;
+
 fn main() {
-    println!("Hello, world!");
+    println!("Welcome to conventional commit CLI! 🤗");
+    interactive::run_interactive();
 }


### PR DESCRIPTION
This pull request includes several important changes to improve the functionality and metadata of the project. The most significant changes involve updating the project metadata in `Cargo.toml`, adding a new interactive feature for selecting commit types, and modifying the main function to integrate the new feature.

### Project Metadata Updates:
* [`Cargo.toml`](diffhunk://#diff-2e9d962a08321605940b5a657135052fbcef87b5e360662bb527c96d9a615542L7-R12): Updated the `author` field to include an email address, added `readme`, `homepage`, `repository`, `keywords`, and `categories` fields to provide more comprehensive project metadata.

### New Interactive Feature:
* [`src/interactive.rs`](diffhunk://#diff-6ccaf8d0f6a318edbfa4217862b03e5598c4ad196ace642f396e188facfeb9bbR1-R16): Added a new module `interactive` with a `run_interactive` function that uses the `dialoguer` crate to prompt users to select a commit type interactively.

### Main Function Update:
* [`src/main.rs`](diffhunk://#diff-42cb6807ad74b3e201c5a7ca98b911c5fa08380e942be6e4ac5807f8377f87fcR1-R5): Modified the `main` function to print a welcome message and call the new `run_interactive` function from the `interactive` module.