### PR TITLE
theme

### DIFF
--- a/src/interactive.rs
+++ b/src/interactive.rs
@@ -1,11 +1,14 @@
-use dialoguer::Select;
+use dialoguer::{Select, theme::ColorfulTheme};
 
 pub fn run_interactive() {
+    // theme
+    let theme = ColorfulTheme::default();
+
     // commit types
     let commit_types = vec!["feat", "fix", "chore", "docs", "refactor", "test"];
 
     // prompt for commit type
-    let commit_type = Select::new()
+    let commit_type = Select::with_theme(&theme)
         .with_prompt("Select the type of change")
         .items(&commit_types)
         .default(0)


### PR DESCRIPTION
This pull request includes improvements to the interactive commit selection process by adding a colorful theme to the dialog.

Enhancements to user interface:

* [`src/interactive.rs`](diffhunk://#diff-6ccaf8d0f6a318edbfa4217862b03e5598c4ad196ace642f396e188facfeb9bbL1-R11): Added the `ColorfulTheme` from `dialoguer` to enhance the visual appearance of the commit type selection prompt.