### PR TITLE
Prompt for scope

### DIFF
--- a/src/interactive.rs
+++ b/src/interactive.rs
@@ -1,4 +1,4 @@
-use dialoguer::{Select, theme::ColorfulTheme};
+use dialoguer::{Input, Select, theme::ColorfulTheme};
 
 pub fn run_interactive() {
     // theme
@@ -15,5 +15,12 @@ pub fn run_interactive() {
         .interact()
         .expect("Failed to select commit type");
 
+    // prompt for scope
+    let scope: String = Input::with_theme(&theme)
+        .with_prompt("Enter the scope")
+        .interact_text()
+        .expect("Failed to read scope");
+
     println!("Selected commit type: {}", commit_types[commit_type]);
+    println!("scope: {scope}");
 }


### PR DESCRIPTION
This pull request includes enhancements to the interactive commit message prompt in `src/interactive.rs`. The changes introduce a new theme for the prompts and add an additional input for specifying the scope of the commit.

Enhancements to the interactive commit message prompt:

* [`src/interactive.rs`](diffhunk://#diff-6ccaf8d0f6a318edbfa4217862b03e5598c4ad196ace642f396e188facfeb9bbL1-R25): Added `Input` and `ColorfulTheme` from the `dialoguer` crate to enhance the user interface of the prompts.
* [`src/interactive.rs`](diffhunk://#diff-6ccaf8d0f6a318edbfa4217862b03e5598c4ad196ace642f396e188facfeb9bbL1-R25): Integrated a new theme (`ColorfulTheme`) for the prompts to improve visual appeal.
* [`src/interactive.rs`](diffhunk://#diff-6ccaf8d0f6a318edbfa4217862b03e5598c4ad196ace642f396e188facfeb9bbL1-R25): Added a new input prompt for the user to enter the scope of the commit, which is then displayed alongside the selected commit type.