### PR TITLE
realease

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,25 +1,23 @@
 name: CI
 
 on:
-  pull_request:
   push:
     branches:
       - main
       - master
       - develop
+  pull_request:
 
 env:
   CARGO_TERM_COLOR: always
 
-# ensure that the workflow is only triggered once per PR, subsequent pushes to the PR will cancel
-# and restart the workflow. See https://docs.github.com/en/actions/using-jobs/using-concurrency
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
   cancel-in-progress: true
 
 jobs:
   fmt:
-    name: fmt
+    name: Formatting
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -28,12 +26,13 @@ jobs:
         uses: dtolnay/rust-toolchain@stable
         with:
           components: rustfmt
-      - name: check formatting
+      - name: Check formatting
         run: cargo fmt -- --check
       - name: Cache Cargo dependencies
         uses: Swatinem/rust-cache@v2
+
   clippy:
-    name: clippy
+    name: Linting
     runs-on: ubuntu-latest
     permissions:
       checks: write
@@ -44,46 +43,71 @@ jobs:
         uses: dtolnay/rust-toolchain@stable
         with:
           components: clippy
-      - name: Run clippy action
-        uses: clechasseur/rs-clippy-check@v3
+      - name: Run Clippy
+        run: cargo clippy -- -D warnings
       - name: Cache Cargo dependencies
         uses: Swatinem/rust-cache@v2
+
   doc:
-    # run docs generation on nightly rather than stable. This enables features like
-    # https://doc.rust-lang.org/beta/unstable-book/language-features/doc-cfg.html which allows an
-    # API be documented as only available in some specific platforms.
-    name: doc
+    name: Documentation
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - name: Checkout
+        uses: actions/checkout@v4
       - name: Install Rust nightly
         uses: dtolnay/rust-toolchain@nightly
-      - name: Run cargo doc
+      - name: Generate Documentation
         run: cargo doc --no-deps --all-features
         env:
           RUSTDOCFLAGS: --cfg docsrs
+
   test:
+    name: Testing
     runs-on: ${{ matrix.os }}
-    name: test ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
         os: [macos-latest, windows-latest]
     steps:
-      # if your project needs OpenSSL, uncomment this to fix Windows builds.
-      # it's commented out by default as the install command takes 5-10m.
-      # - run: echo "VCPKG_ROOT=$env:VCPKG_INSTALLATION_ROOT" | Out-File -FilePath $env:GITHUB_ENV -Append
-      #   if: runner.os == 'Windows'
-      # - run: vcpkg install openssl:x64-windows-static-md
-      #   if: runner.os == 'Windows'
-      - uses: actions/checkout@v4
-      - name: Install Rust
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Install Rust stable
         uses: dtolnay/rust-toolchain@stable
-      # enable this ci template to run regardless of whether the lockfile is checked in or not
-      - name: cargo generate-lockfile
+      - name: Generate lockfile if missing
         if: hashFiles('Cargo.lock') == ''
         run: cargo generate-lockfile
-      - name: cargo test --locked
+      - name: Run Tests
         run: cargo test --locked --all-features --all-targets
       - name: Cache Cargo dependencies
         uses: Swatinem/rust-cache@v2
+
+  build:
+    name: Build
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Install Rust stable
+        uses: dtolnay/rust-toolchain@stable
+      - name: Build Project
+        run: cargo build --release
+      - name: Cache Cargo dependencies
+        uses: Swatinem/rust-cache@v2
+
+  release:
+    name: Release
+    runs-on: ubuntu-latest
+    needs: [build]  # Ensure build completes successfully before releasing
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Install Rust stable
+        uses: dtolnay/rust-toolchain@stable
+      - name: Install cargo-release
+        run: cargo install cargo-release
+      - name: Run cargo release
+        env:
+          CARGO_TERM_COLOR: always
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: cargo release
+


### PR DESCRIPTION
This pull request includes several updates and improvements to the CI workflow configuration in the `.github/workflows/ci.yml` file. The most important changes include renaming job names for clarity, adding new jobs for building and releasing the project, and modifying existing job steps for consistency and readability.

Improvements to job names and steps:

* Renamed job names for clarity and consistency, such as changing `fmt` to `Formatting`, `clippy` to `Linting`, `doc` to `Documentation`, and `test` to `Testing`. [[1]](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fL4-R20) [[2]](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fL31-R35) [[3]](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fL47-R113)
* Updated step names within jobs to use consistent and descriptive names, such as changing `check formatting` to `Check formatting` and `Run clippy action` to `Run Clippy`. [[1]](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fL31-R35) [[2]](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fL47-R113)

New jobs added:

* Added a `build` job to compile the project in release mode, ensuring that the build process is tested.
* Added a `release` job to automate the release process, which depends on the successful completion of the `build` job. This job installs `cargo-release` and runs `cargo release`.