### PR TITLE
feat: define comprehensive token types for commit message compiler

### DIFF
--- a/src/compiler/token.rs
+++ b/src/compiler/token.rs
@@ -97,11 +97,10 @@ impl fmt::Display for Token {
             Token::Colon => write!(f, "Colon"),
             Token::Breaking => write!(f, "Breaking"),
             Token::Description(s) => {
-                let preview = if s.len() > 30 {
-                    format!("{}...", &s[..30])
-                } else {
-                    s.clone()
-                };
+                let mut preview: String = s.chars().take(30).collect();
+                if s.chars().count() > 30 {
+                    preview.push_str("...");
+                }
                 write!(f, "Description({})", preview)
             }
             Token::Body(s) => {


### PR DESCRIPTION
### **PR Type**
Enhancement


___

### **Description**
- Replaced empty token enum with comprehensive Token variants for conventional commits

- Added Type, Scope, Breaking, Description, Body, Footer, Newline, and Eof token types

- Implemented utility methods: type_name(), value(), is_breaking(), is_newline(), is_eof()

- Added Display trait implementation and extensive test coverage for all token types


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Empty Token Enum"] -->|"Replace with variants"| B["Token Enum with 8 variants"]
  B -->|"Add methods"| C["Utility Methods"]
  B -->|"Add trait"| D["Display Implementation"]
  B -->|"Add tests"| E["13 Test Cases"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>token.rs</strong><dd><code>Implement comprehensive Token enum with methods and tests</code></dd></summary>
<hr>

src/compiler/token.rs

<ul><li>Replaced empty <code>TokenKind</code> enum and <code>Token</code> struct with a comprehensive <br><code>Token</code> enum containing 8 variants representing different parts of <br>conventional commit messages<br> <li> Implemented helper methods: <code>type_name()</code> for human-readable token type <br>names, <code>value()</code> to extract string content, and three boolean predicates <br>(<code>is_breaking()</code>, <code>is_newline()</code>, <code>is_eof()</code>)<br> <li> Added <code>Display</code> trait implementation with truncation for long <br>descriptions and body text<br> <li> Added 13 comprehensive unit tests covering token instantiation, type <br>names, value extraction, predicates, display formatting, cloning, and <br>equality comparisons</ul>


</details>


  </td>
  <td><a href="https://github.com/tgenericx/commando/pull/76/files#diff-53f5a6785c4252dfe6ce652deb9df33a7fde158332294c8899770c9ececb7d44">+249/-4</a>&nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

